### PR TITLE
Gallery: fix head cropping

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -10,15 +10,16 @@
     />
     <link rel="stylesheet" href="/assets/css/site.f3c51a6396.css" />
     <style>
-      /* Stop fixed-height cropping. Keep a consistent tile shape and bias focus upward */
+      /* Stop fixed-height cropping. Keep consistent tiles and bias focus upward */
       .gallery-img {
         display: block;
         width: 100%;
-        aspect-ratio: 4 / 3;     /* change to 3/2 if you prefer taller tiles */
+        height: auto !important;   /* override any prior fixed height */
+        aspect-ratio: 4 / 3;       /* change to 3/2 if you want taller tiles */
         object-fit: cover;
-        object-position: 50% 40%; /* nudge up so heads are safer */
+        object-position: 50% 40%;  /* nudge up so faces are safer */
       }
-      /* Per-image overrides if a photo still crops badly */
+      /* Per-image overrides */
       .gallery-img[data-focus="top"]    { object-position: 50% 15%; }
       .gallery-img[data-focus="center"] { object-position: 50% 50%; }
       .gallery-img[data-focus="bottom"] { object-position: 50% 85%; }


### PR DESCRIPTION
Kill fixed-height with \!important; 4:3 aspect-ratio; top bias. Optionally uses Bootstrap ratio wrapper.