### PR TITLE
Fix: Lent bows WebP thumb path

### DIFF
--- a/etiquette/bows-lent.html
+++ b/etiquette/bows-lent.html
@@ -83,7 +83,7 @@
 
 
 <div class="col-12 col-lg-5">
-    <source srcset="/assets/img/etiquette/thumb-bows-lent.webp" type="image/webp">
+    <source srcset="/assets/img/etiquette/thumbs/lent-bows.webp" type="image/webp">
     <picture>
   <source srcset="/assets/img/etiquette/large-lent-bows.webp" type="image/webp">
   <img src="/assets/img/etiquette/large-lent-bows.jpg" alt="" class="img-fluid d-block w-100" loading="lazy" style="max-width:100%;height:auto">


### PR DESCRIPTION
Corrected invalid WebP thumb path and moved sources inside <picture>. No other files touched.