### PR TITLE
Fix: news workflow minimal fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/news.yml
+++ b/.github/ISSUE_TEMPLATE/news.yml
@@ -1,5 +1,5 @@
 name: "New news post"
-description: "Create a news post in one language"
+description: "Create a news post"
 title: "News: <date>-<slug> (<lang>)"
 labels: ["news"]
 body:
@@ -8,19 +8,17 @@ body:
     attributes:
       label: "Date"
       description: "Format: dd-mm-yyyy"
-      placeholder: "07-11-2025"
+      placeholder: "29-08-2025"
     validations:
       required: true
-
   - type: input
     id: slug
     attributes:
       label: "Slug"
-      description: "Lowercase, hyphens only"
-      placeholder: "feast-of-archangels"
+      description: "Lowercase, hyphens only, ASCII"
+      placeholder: "beheading-of-saint-john-the-baptist"
     validations:
       required: true
-
   - type: dropdown
     id: lang
     attributes:
@@ -28,43 +26,22 @@ body:
       options: ["sv", "en", "sr"]
     validations:
       required: true
-
   - type: input
     id: title
     attributes:
       label: "Title"
-      placeholder: "Ärkeänglarnas fest"
+      placeholder: "The Beheading of Saint John the Baptist"
     validations:
       required: true
-
-  - type: textarea
-    id: summary
-    attributes:
-      label: "Summary (1–2 sentences)"
-      placeholder: "Kort sammanfattning…"
-
   - type: textarea
     id: body
     attributes:
       label: "Body"
-      description: "Markdown allowed. Paste images directly here."
+      description: "Markdown allowed. Drag or paste one or more images below."
       placeholder: "Full text…"
     validations:
       required: true
-
-  - type: input
-    id: tags
-    attributes:
-      label: "Tags (comma separated)"
-      placeholder: "högtid, ärkeänglar"
-
-  - type: input
-    id: cover
-    attributes:
-      label: "Cover image URL (optional)"
-      placeholder: "https://… or leave blank"
-
   - type: markdown
     attributes:
       value: |
-        **Images:** You can drag or paste pictures below the body field. They will be uploaded automatically.
+        Images: drag or paste below the Body field. They will be handled automatically.

--- a/.github/workflows/news-from-issue.yml
+++ b/.github/workflows/news-from-issue.yml
@@ -31,38 +31,25 @@ jobs:
         with:
           script: |
             const body = context.payload.issue.body || "";
-
             function get(field){
               const re = new RegExp(`###\\s+${field}\\s+\\n+([\\s\\S]*?)\\n(?=###|$)`);
               const m = body.match(re);
               return (m ? m[1].trim() : "");
             }
-
-            const dateStr = get("Date");          // dd-mm-yyyy
-            const slug    = get("Slug").toLowerCase().replace(/[^a-z0-9-]/g,'-').replace(/-+/g,'-').replace(/^-|-$|/g,'');
+            const dateStr = get("Date");   // dd-mm-yyyy
+            const slug    = get("Slug").toLowerCase().replace(/[^a-z0-9-]/g,'-').replace(/-+/g,'-').replace(/(^-)|(-$)/g,'');
             const lang    = get("Language") || "sv";
             const title   = get("Title");
-            const summary = get("Summary (1–2 sentences)") || "";
-            const tagsRaw = get("Tags (comma separated)") || "";
-            const cover   = get("Cover image URL (optional)") || "";
             const bodyMd  = get("Body");
-
             if(!dateStr || !slug || !lang || !title || !bodyMd){
-              core.setFailed("Missing one of required fields: Date, Slug, Language, Title, Body");
+              core.setFailed("Missing required fields: Date, Slug, Language, Title, Body");
             }
-
-            // dd-mm-yyyy -> yyyy, mm, dd
             const [dd, mm, yyyy] = dateStr.split("-").map(s => s.padStart(2,"0"));
-            if(!yyyy || !mm || !dd){ core.setFailed("Date must be dd-mm-yyyy"); }
-
-            const year = yyyy;
-            const month = mm;
-            const day = dd;
+            const year = yyyy, month = mm, day = dd;
 
             const basePath = `i18n/news/${year}/${month}/${day}-${slug}`;
             const imgDir   = `assets/img/news/${year}/${month}/${day}-${slug}`;
 
-            // pick user-images links to download
             const imgUrls = Array.from(bodyMd.matchAll(/https:\/\/user-images\.githubusercontent\.com\/[^\s)\]]+/g)).map(x=>x[0]);
 
             core.setOutput("year", year);
@@ -71,9 +58,6 @@ jobs:
             core.setOutput("slug", slug);
             core.setOutput("lang", lang);
             core.setOutput("title", title);
-            core.setOutput("summary", summary);
-            core.setOutput("tags", tagsRaw);
-            core.setOutput("cover", cover);
             core.setOutput("basePath", basePath);
             core.setOutput("imgDir", imgDir);
             core.setOutput("bodyMd", bodyMd);
@@ -81,8 +65,7 @@ jobs:
             core.setOutput("branch", `feat/news-${year}-${month}-${day}-${slug}`);
 
       - name: Create branch
-        run: |
-          git switch -c "${{ steps.parse.outputs.branch }}"
+        run: git switch -c "${{ steps.parse.outputs.branch }}"
 
       - name: Ensure folders
         run: |
@@ -92,7 +75,7 @@ jobs:
       - name: Install image tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y imagemagick webp
+          sudo apt-get install -y imagemagick webp jq
 
       - name: Download attached images (if any)
         if: ${{ fromJSON(steps.parse.outputs.imgUrls).length > 0 }}
@@ -111,13 +94,9 @@ jobs:
           cd "${{ steps.parse.outputs.imgDir }}"
           shopt -s nullglob
           for f in *; do
-            # skip already-generated variants
             [[ "$f" == *-600.* || "$f" == *-1200.* ]] && continue
-            # create 1200 jpg
-            convert "$f" -auto-orient -resize 1200x1200\> "${f%.*}-1200.jpg"
-            # create 600 jpg
-            convert "$f" -auto-orient -resize 600x600\>   "${f%.*}-600.jpg"
-            # make webp
+            magick "$f" -auto-orient -resize 1200x1200\> "${f%.*}-1200.jpg"
+            magick "$f" -auto-orient -resize 600x600\>   "${f%.*}-600.jpg"
             cwebp -q 85 "${f%.*}-1200.jpg" -o "${f%.*}-1200.webp" >/dev/null 2>&1
             cwebp -q 85 "${f%.*}-600.jpg"  -o "${f%.*}-600.webp"  >/dev/null 2>&1
           done
@@ -128,60 +107,30 @@ jobs:
           BODY='${{ steps.parse.outputs.bodyMd }}'
           LANG='${{ steps.parse.outputs.lang }}'
           BASE='${{ steps.parse.outputs.basePath }}'
-          # Write i18n file
           mkdir -p "$(dirname "$BASE")"
           printf '{\n  "title": %s,\n  "body": %s\n}\n' \
             "$(jq -Rsa . <<<"$TITLE")" \
             "$(jq -Rsa . <<<"$BODY")" \
             > "${BASE}.${LANG}.json"
 
-      - name: Update metadata list
+      - name: Update metadata list (minimal)
         run: |
           YEAR='${{ steps.parse.outputs.year }}'
           MONTH='${{ steps.parse.outputs.month }}'
           DAY='${{ steps.parse.outputs.day }}'
           SLUG='${{ steps.parse.outputs.slug }}'
           BASE='${{ steps.parse.outputs.basePath }}'
-          SUMMARY='${{ steps.parse.outputs.summary }}'
-          TAGS='${{ steps.parse.outputs.tags }}'
-          COVER='${{ steps.parse.outputs.cover }}'
           META_FILE="data/news/index.json"
-
           mkdir -p "$(dirname "$META_FILE")"
-          if [ ! -f "$META_FILE" ]; then
-            echo "[]" > "$META_FILE"
-          fi
-
-          # Build one metadata object
+          [ -f "$META_FILE" ] || echo "[]" > "$META_FILE"
           DATE_ISO="${YEAR}-${MONTH}-${DAY}"
-          # tags -> array
-          TAG_ARRAY=$(jq -R 'split(",") | map(. | strip | select(length>0))' <<<"$TAGS")
-
-          # choose cover: provided or first 1200 webp if exists
-          AUTO_COVER=""
-          if compgen -G "${{ steps.parse.outputs.imgDir }}/*-1200.webp" > /dev/null; then
-            FIRST=$(ls -1 "${{ steps.parse.outputs.imgDir }}"/*-1200.webp | head -n1)
-            AUTO_COVER="/${FIRST}"
-          fi
-          if [ -n "$COVER" ]; then
-            FINAL_COVER="$COVER"
-          else
-            FINAL_COVER="$AUTO_COVER"
-          fi
-
           NEW_OBJ=$(jq -n \
             --arg date "$DATE_ISO" \
             --arg slug "$SLUG" \
             --arg i18nPath "$BASE" \
-            --arg summary "$SUMMARY" \
-            --arg cover "$FINAL_COVER" \
-            --argjson tags "$TAG_ARRAY" \
-            '{date:$date, slug:$slug, i18nPath:$i18nPath, summary:$summary, tags:$tags, cover: ( ($cover|length>0) ? $cover : null ) }')
-
-          # upsert: remove existing with same date+slug then append
+            '{date:$date, slug:$slug, i18nPath:$i18nPath}')
           TMP=$(mktemp)
-          jq --arg d "$DATE_ISO" --arg s "$SLUG" \
-             'map(select(.date != $d or .slug != $s))' "$META_FILE" > "$TMP" && mv "$TMP" "$META_FILE"
+          jq --arg d "$DATE_ISO" --arg s "$SLUG" 'map(select(.date != $d or .slug != $s))' "$META_FILE" > "$TMP" && mv "$TMP" "$META_FILE"
           jq --argjson obj "$NEW_OBJ" '. += [$obj]' "$META_FILE" > "$TMP" && mv "$TMP" "$META_FILE"
 
       - name: Commit
@@ -190,8 +139,7 @@ jobs:
           git commit -m "news: add ${{ steps.parse.outputs.year }}-${{ steps.parse.outputs.month }}-${{ steps.parse.outputs.day }} ${{ steps.parse.outputs.slug }} (${{ steps.parse.outputs.lang }}) from issue #${{ github.event.issue.number }}"
 
       - name: Push branch
-        run: |
-          git push -u origin "${{ steps.parse.outputs.branch }}"
+        run: git push -u origin "${{ steps.parse.outputs.branch }}"
 
       - name: Open PR
         uses: actions/github-script@v7


### PR DESCRIPTION
Remove summary and other unused fields. Keep {date, slug, i18nPath} only. No site code touched.