### PR TITLE
Fix: empty issue title; remove 'News:' prefix

### DIFF
--- a/.github/ISSUE_TEMPLATE/news.yml
+++ b/.github/ISSUE_TEMPLATE/news.yml
@@ -1,6 +1,6 @@
 name: "New news post"
 description: "Create a news post"
-title: "News: <date>-<slug> (<lang>)"
+title: ""
 labels: ["news"]
 body:
   - type: input

--- a/.github/workflows/news-from-issue.yml
+++ b/.github/workflows/news-from-issue.yml
@@ -148,7 +148,7 @@ jobs:
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `News: ${context.payload.issue.title}`,
+              title: context.payload.issue.title,
               head: '${{ steps.parse.outputs.branch }}',
               base: 'main',
               body: `Automated PR for news post from issue #${context.payload.issue.number}.`


### PR DESCRIPTION
Issue template title is now empty. Workflow no longer checks/uses 'News:'; PR title mirrors issue title.