### PR TITLE
Issue form: remove default title

### DIFF
--- a/.github/ISSUE_TEMPLATE/news.yml
+++ b/.github/ISSUE_TEMPLATE/news.yml
@@ -1,4 +1,5 @@
 name: "New news post"
+title: "Add Title"
 description: "Create a news post"
 title: ""
 labels: ["news"]


### PR DESCRIPTION
Remove the title key from .github/ISSUE_TEMPLATE/news.yml so the form renders and users type the real title.