### PR TITLE
ci: run news job on every issue opened/edited; drop brittle job-level…

### DIFF
--- a/.github/workflows/news-from-issue.yml
+++ b/.github/workflows/news-from-issue.yml
@@ -12,10 +12,6 @@ permissions:
 jobs:
   build-news:
     # Run only for our issue form (checks for required headings in the body)
-    if: >
-      contains(github.event.issue.body, "### Date") &&
-      contains(github.event.issue.body, "### Language") &&
-      contains(github.event.issue.body, "### Body")
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
… gate

## What changed
- 

## Why
- 

## Screenshots / test URLs
- Live preview after merge: https://serbianorthodox.github.io/?cachebust=1
- Page(s) touched:

## Checks
- [ ] Builds locally
- [ ] Pages workflow is green
- [ ] i18n keys exist for sv and sr (no empty bullets)
- [ ] Images load (no .webp 404s), lazy-loading present
