### PR TITLE
issues: enable template chooser (disable blank issues)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Website help / questions
+    url: https://github.com/serbianorthodox/serbianorthodox.github.io/discussions
+    about: Ask questions or request support here.


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Screenshots / test URLs
- Live preview after merge: https://serbianorthodox.github.io/?cachebust=1
- Page(s) touched:

## Checks
- [ ] Builds locally
- [ ] Pages workflow is green
- [ ] i18n keys exist for sv and sr (no empty bullets)
- [ ] Images load (no .webp 404s), lazy-loading present
