### PR TITLE
fix: ensure workflow_dispatch trigger active

### DIFF
--- a/.github/workflows/news-from-issue.yml
+++ b/.github/workflows/news-from-issue.yml
@@ -3,7 +3,7 @@ name: "News from Issue"
 on:
   issues:
     types: [opened, edited]
-  workflow_dispatch:
+workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Screenshots / test URLs
- Live preview after merge: https://serbianorthodox.github.io/?cachebust=1
- Page(s) touched:

## Checks
- [ ] Builds locally
- [ ] Pages workflow is green
- [ ] i18n keys exist for sv and sr (no empty bullets)
- [ ] Images load (no .webp 404s), lazy-loading present
