### PR TITLE
fix: replace workflow with clean, valid version (dispatch + dd-mm-yyy…

### DIFF
--- a/.github/workflows/news-from-issue.yml
+++ b/.github/workflows/news-from-issue.yml
@@ -1,4 +1,4 @@
-name: "News Auto from Issue"
+name: "News from Issue"
 
 on:
   issues:
@@ -39,11 +39,11 @@ jobs:
             if (!rawTitle) { core.setFailed("Missing Issue Title"); return; }
             if (!rawBody)  { core.setFailed("Missing Issue Body");  return; }
 
-            // Language: first line "Language: en|sv|sr" (case-insensitive). Default en.
+            // Language line "Language: en|sv|sr" (anywhere). Default en.
             const langMatch = rawBody.match(/^\s*Language:\s*(en|sv|sr)\s*$/im);
             const lang = (langMatch ? langMatch[1].toLowerCase() : "en");
 
-            // Strip scaffolding (keep pure body to store)
+            // Clean body: drop Language line and scaffold headings
             const bodyClean = rawBody
               .replace(/^\s*Language:\s*(en|sv|sr)\s*$/gim, "")
               .replace(/^###\s*Date[\s\S]*?(\r?\n){2}/im, "")
@@ -55,13 +55,13 @@ jobs:
               core.setFailed("Body too short (min 20 chars)"); return;
             }
 
-            // Title: drop leading date and "News:" if present
+            // Title: strip leading dd-mm-yyyy and optional "News:"
             const title = rawTitle
               .replace(/^\s*\d{2}-\d{2}-\d{4}\s*[:–-]\s*/,"")
               .replace(/^News:\s*/,"")
               .trim();
 
-            // Date rules: use ### Date (if valid), else today in Europe/Stockholm. Always dd-mm-yyyy.
+            // --- Date handling: prefer ### Date; else today Europe/Stockholm. Always dd-mm-yyyy.
             function todaySE() {
               const parts = new Intl.DateTimeFormat('sv-SE', {
                 timeZone: 'Europe/Stockholm', day:'2-digit', month:'2-digit', year:'numeric'
@@ -93,7 +93,7 @@ jobs:
             const date_display = normDate(dateField);              // dd-mm-yyyy
             const [dd, mm, yyyy] = date_display.split("-");
 
-            // Slugify ASCII-kebab (deterministic). We mint once per date.
+            // Slugify (ASCII kebab). Mint once per date.
             function slugify(s){
               return (s || "news")
                 .normalize("NFKD").replace(/[\u0300-\u036f]/g, "")
@@ -102,7 +102,7 @@ jobs:
             }
             const computedSlug = slugify(title);
 
-            // Slug locking via index.json: single entry per date (dd-mm-yyyy)
+            // Slug/date lock via index.json (single entry per dd-mm-yyyy)
             const metaPath = "data/news/index.json";
             let index = [];
             if (fs.existsSync(metaPath)) {
@@ -144,7 +144,7 @@ jobs:
           set -e
           cd "${{ steps.parse.outputs.imgDir }}"
           BODY='${{ github.event.issue.body }}'
-          # Extract unique GitHub-hosted image URLs and download them
+          # GitHub-hosted image URLs only
           printf "%s" "$BODY" \
             | grep -Eo 'https://(user-images\.githubusercontent\.com|github\.com/user-attachments)/[^ )]+' \
             | awk '!seen[$0]++' \
@@ -162,7 +162,6 @@ jobs:
           for f in *; do
             [[ -f "$f" ]] || continue
             [[ "$f" == *-600.* || "$f" == *-1200.* ]] && continue
-            # Create 1200 and 600 JPG, then WebP; without enlarging
             magick "$f" -auto-orient -resize 1200x1200\> "${f%.*}-1200.jpg" || true
             magick "$f" -auto-orient -resize 600x600\>   "${f%.*}-600.jpg"  || true
             [ -f "${f%.*}-1200.jpg" ] && cwebp -q 85 "${f%.*}-1200.jpg" -o "${f%.*}-1200.webp" >/dev/null 2>&1 || true
@@ -201,7 +200,7 @@ jobs:
               try { index = JSON.parse(fs.readFileSync(metaPath, "utf8")); } catch { index = []; }
             }
 
-            // Upsert single entry per date
+            // Upsert one row per date; keep newest on top
             const existing = index.find(e => e.date === date_display);
             if (existing) {
               if (!existing.slug) existing.slug = slug;
@@ -210,7 +209,6 @@ jobs:
               index.push({ date: date_display, slug, i18nPath: basePath });
             }
 
-            // Sort by dd-mm-yyyy descending (latest on top)
             index.sort((a,b) => {
               const [ad,am,ay] = String(a.date).split("-").map(Number);
               const [bd,bm,by] = String(b.date).split("-").map(Number);
@@ -227,7 +225,6 @@ jobs:
 
       - name: Push branch
         run: |
-          # Only push if there were changes
           if git diff --cached --quiet; then
             echo "Nothing to push."
           else
@@ -240,7 +237,6 @@ jobs:
         with:
           script: |
             const branch = '${{ steps.parse.outputs.branch }}';
-            // If nothing was pushed (no changes), skip PR.
             const { data: heads } = await github.rest.repos.listBranches({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -259,4 +255,3 @@ jobs:
               body: `Automated PR from issue #${context.payload.issue.number}\n\nDate: ${'${{ steps.parse.outputs.date_display }}'}\nSlug: ${'${{ steps.parse.outputs.slug }}'}\nLang: ${'${{ steps.parse.outputs.lang }}'}\ni18nPath: ${'${{ steps.parse.outputs.basePath }}'}`
             });
             core.info(`PR opened: ${pr.html_url}`);
-# reindex3


### PR DESCRIPTION
…y + slug lock)

## What changed
- 

## Why
- 

## Screenshots / test URLs
- Live preview after merge: https://serbianorthodox.github.io/?cachebust=1
- Page(s) touched:

## Checks
- [ ] Builds locally
- [ ] Pages workflow is green
- [ ] i18n keys exist for sv and sr (no empty bullets)
- [ ] Images load (no .webp 404s), lazy-loading present
