### PR TITLE
fix(workflow): always push news branch so PR can be opened

### DIFF
--- a/.github/workflows/news-from-issue.yml
+++ b/.github/workflows/news-from-issue.yml
@@ -239,11 +239,7 @@ jobs:
 
       - name: Push branch
         run: |
-          if git diff --cached --quiet; then
-            echo "Nothing to push."
-          else
-            git push -u origin "${{ steps.parse.outputs.branch }}"
-          fi
+          git push -u origin "${{ steps.parse.outputs.branch }}"
 
       - name: Open PR
         if: ${{ !cancelled() && !failure() }}


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Screenshots / test URLs
- Live preview after merge: https://serbianorthodox.github.io/?cachebust=1
- Page(s) touched:

## Checks
- [ ] Builds locally
- [ ] Pages workflow is green
- [ ] i18n keys exist for sv and sr (no empty bullets)
- [ ] Images load (no .webp 404s), lazy-loading present
