### PR TITLE
fix: correct workflow_dispatch indentation so manual trigger works

### DIFF
--- a/.github/workflows/news-from-issue.yml
+++ b/.github/workflows/news-from-issue.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, edited]
   workflow_dispatch:
 
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Screenshots / test URLs
- Live preview after merge: https://serbianorthodox.github.io/?cachebust=1
- Page(s) touched:

## Checks
- [ ] Builds locally
- [ ] Pages workflow is green
- [ ] i18n keys exist for sv and sr (no empty bullets)
- [ ] Images load (no .webp 404s), lazy-loading present
