### PR TITLE
ci: fix YAML syntax (replace heredoc with printf)

### DIFF
--- a/.github/workflows/news-from-issue-revived.yml
+++ b/.github/workflows/news-from-issue-revived.yml
@@ -131,9 +131,7 @@ jobs:
         run: |
           mkdir -p .news_tmp
           cat > .news_tmp/body.txt <<'EOF'
-${{ steps.parse.outputs.bodyMd }}
-EOF
-
+      - name: Save cleaned body to file (verbatim)n        env:n          BODY: ${{ steps.parse.outputs.bodyMd }}n        run: |n          mkdir -p .news_tmpn          printf "%s" "$BODY" > .news_tmp/body.txt
       - name: Create branch
         run: git switch -c "${{ steps.parse.outputs.branch }}"
 


### PR DESCRIPTION
Removed invalid heredoc causing YAML parser error.