### PR TITLE
fix: force workflow re-registration (no logic change)

### DIFF
--- a/.github/workflows/news-from-issue-revived.yml
+++ b/.github/workflows/news-from-issue-revived.yml
@@ -136,3 +136,4 @@ jobs:
           PR_TITLE="News: ${BRANCH}"
           gh pr create --head "$BRANCH" --base "main" --title "$PR_TITLE" --body "Automated news update from issue."
 YAML
+


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Screenshots / test URLs
- Live preview after merge: https://serbianorthodox.github.io/?cachebust=1
- Page(s) touched:

## Checks
- [ ] Builds locally
- [ ] Pages workflow is green
- [ ] i18n keys exist for sv and sr (no empty bullets)
- [ ] Images load (no .webp 404s), lazy-loading present
