### PR TITLE
fix/news processor reset

### DIFF
--- a/.github/workflows/news-processor.yml
+++ b/.github/workflows/news-processor.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   build-news:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -138,10 +137,14 @@ jobs:
           git push -u origin "$BR"
           echo "branch=$BR" >> "$GITHUB_OUTPUT"
 
-      - name: Open PR
+      - name: Open PR (only on issue event)
+        if: ${{ github.event_name == 'issues' }}
         env:
           BRANCH: ${{ steps.git.outputs.branch }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          PR_TITLE="News: ${BRANCH}"
-          gh pr create --head "$BRANCH" --base "main" --title "$PR_TITLE" --body "Automated news update from issue."
+          [ -n "$BRANCH" ] || { echo "Empty BRANCH"; exit 1; }
+          gh pr create --head "$BRANCH" --base "main" \
+            --title "News: ${BRANCH}" \
+            --body "Automated news update from issue."


### PR DESCRIPTION
- **remove legacy news workflow**
- **remove: legacy news-from-issue workflow**
- **workflow(news): force re-registration under new identity**
- **ci(news): reset News Processor workflow**
