### PR TITLE
fix(news): use date from issue when provided

### DIFF
--- a/.github/workflows/news-processor.yml
+++ b/.github/workflows/news-processor.yml
@@ -46,6 +46,45 @@ jobs:
             exit 1
           fi
 
+          # --- Date: from '### Date' section (dd-mm-yyyy) or fallback to today ---
+          DATE_RAW="$(printf '%s\n' "$RAW_BODY" | awk '
+            BEGIN { mode=0 }
+            {
+              line = $0
+              low  = tolower(line)
+
+              if (mode == 0 && low ~ /^###[[:space:]]*date[[:space:]]*$/) {
+                mode = 1
+                next
+              }
+
+              if (mode == 1) {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+                if (line == "") next
+                print line
+                exit
+              }
+            }
+          ')"
+
+          if [[ -n "$DATE_RAW" ]]; then
+            # Expect dd-mm-yyyy from the editor
+            if [[ "$DATE_RAW" =~ ^([0-3][0-9])-([0-1][0-9])-([0-9]{4})$ ]]; then
+              DAY="${BASH_REMATCH[1]}"
+              MONTH="${BASH_REMATCH[2]}"
+              YEAR="${BASH_REMATCH[3]}"
+              DATE="${YEAR}-${MONTH}-${DAY}"
+            else
+              echo "WARNING: Invalid date '$DATE_RAW', falling back to today." >&2
+              DATE="$(TZ="${TZ:-Europe/Stockholm}" date +%F)"
+            fi
+          else
+            DATE="$(TZ="${TZ:-Europe/Stockholm}" date +%F)"
+          fi
+
+          YEAR="${DATE%%-*}"
+          MONTH="$(printf '%s' "$DATE" | cut -d- -f2)"
+
           # --- Language: must come from '### Language' section ---
           BODY_LANG="$(printf '%s\n' "$RAW_BODY" | awk '
             BEGIN { mode=0 }
@@ -113,11 +152,6 @@ jobs:
             echo "ERROR: Could not extract news body from issue. Expected a non-empty '### Body' section." >&2
             exit 1
           fi
-
-          # --- Date ---
-          DATE="$(TZ="${TZ:-Europe/Stockholm}" date +%F)"
-          YEAR="${DATE%%-*}"
-          MONTH="$(printf '%s' "$DATE" | cut -d- -f2)"
 
           # --- Slug ---
           SLUG="$(printf '%s' "$TITLE_TRIMMED" \


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Screenshots / test URLs
- Live preview after merge: https://serbianorthodox.github.io/?cachebust=1
- Page(s) touched:

## Checks
- [ ] Builds locally
- [ ] Pages workflow is green
- [ ] i18n keys exist for sv and sr (no empty bullets)
- [ ] Images load (no .webp 404s), lazy-loading present
